### PR TITLE
omit .map files from watch files of Browsersync

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -261,7 +261,7 @@ gulp.task('serve', ['pre:serve'], function () {
         '/node_modules': 'node_modules'
       }
     },
-    files: ['app/**/*.html', '.tmp/**']
+    files: ['app/**/*.html', '.tmp/**', '!.tmp/**/*.map']
   });
   gulp.watch('app/scripts/*.js', function (event) {
     if (event.type === 'added' || event.type === 'renamed') {


### PR DESCRIPTION
I omitted .map files from watched files of Browsersync in order to make css injection enable.
Would you please confirm it?